### PR TITLE
Fix non escaped @ in yaml

### DIFF
--- a/controllers/mail/config_form.yaml
+++ b/controllers/mail/config_form.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 name: mja.mail::lang.controllers.mail.title
-form: @/plugins/mja/mail/models/email/fields.yaml
+form: $/mja/mail/models/email/fields.yaml
 modelClass: Mja\Mail\Models\Email
 defaultRedirect: mja/mail/mail
 

--- a/controllers/mail/config_list.yaml
+++ b/controllers/mail/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 title: mja.mail::lang.controllers.mail.mails_sent
-list: @/plugins/mja/mail/models/email/columns.yaml
+list: $/mja/mail/models/email/columns.yaml
 modelClass: Mja\Mail\Models\Email
 recordUrl: mja/mail/mail/preview/:id
 

--- a/controllers/template/config_form.yaml
+++ b/controllers/template/config_form.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 name: mja.mail::lang.controllers.template.title
-form: @/plugins/mja/mail/models/email/fields.yaml
+form: $/mja/mail/models/email/fields.yaml
 modelClass: Mja\Mail\Models\Email
 defaultRedirect: mja/mail/mail
 

--- a/controllers/template/config_list.yaml
+++ b/controllers/template/config_list.yaml
@@ -3,7 +3,7 @@
 # ===================================
 
 title: mja.mail::lang.controllers.template.title
-list: @/plugins/mja/mail/models/template/columns.yaml
+list: $/mja/mail/models/template/columns.yaml
 modelClass: System\Models\MailTemplate
 recordUrl: mja/mail/template/stats/:id
 

--- a/models/email/columns.yaml
+++ b/models/email/columns.yaml
@@ -40,7 +40,7 @@ columns:
     sent:
         label: mja.mail::lang.models.email.sent
         type: partial
-        path: @/plugins/mja/mail/models/email/_sent.htm
+        path: $/mja/mail/models/email/_sent.htm
         sortable: false
 
     times_opened:


### PR DESCRIPTION
In build 345 with bleeding edge updates non escaped `@` sign throws YAML error. The solution is to escaped it with `'` or here we can use `$`.
